### PR TITLE
Breaking change in GoogleProvider between laravel/socialite:2.0.21 and laravel/socialite:2.0.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
+# SPLessons Changes
+I have forked the df-oauth repository under my profile isreehari/df-oauth. We will keep add our modifications our repositry
+   if there is new release happens in upstream repository we will compare and merge with our changes. We should always pull 
+   upstream changes from ***upstream master branch to spl-updated branch***
+
+
 # df-oauth
 DreamFactory OAuth support.
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,2 @@
-# SPLessons Changes
-I have forked the df-oauth repository under my profile isreehari/df-oauth. We will keep add our modifications our repositry
-   if there is new release happens in upstream repository we will compare and merge with our changes. We should always pull 
-   upstream changes from ***upstream master branch to spl-updated branch***
-
-
 # df-oauth
 DreamFactory OAuth support.
-

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":        "splessons/df-oauth",
+  "name":        "dreamfactory/df-oauth",
   "description": "OAuth support for DreamFactory Platform 2.0",
   "keywords":    [
     "dreamfactory",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":        "dreamfactory/df-oauth",
+  "name":        "splessons/df-oauth",
   "description": "OAuth support for DreamFactory Platform 2.0",
   "keywords":    [
     "dreamfactory",

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -210,10 +210,11 @@ abstract class BaseOAuthService extends BaseRestService
 
         if (empty($email)) {
             $email = $OAuthUser->getId() . '+' . $serviceName . '@' . $serviceName . '.com';
-        } else {
-            list($emailId, $domain) = explode('@', $email);
-            $email = $emailId . '+' . $serviceName . '@' . $domain;
-        }
+        } 
+        // else {
+        //     list($emailId, $domain) = explode('@', $email);
+        //     $email = $emailId . '+' . $serviceName . '@' . $domain;
+        // }
 
         $user = User::whereEmail($email)->first();
 

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -210,11 +210,10 @@ abstract class BaseOAuthService extends BaseRestService
 
         if (empty($email)) {
             $email = $OAuthUser->getId() . '+' . $serviceName . '@' . $serviceName . '.com';
-        } 
-        // else {
-        //     list($emailId, $domain) = explode('@', $email);
-        //     $email = $emailId . '+' . $serviceName . '@' . $domain;
-        // }
+        } else {
+            list($emailId, $domain) = explode('@', $email);
+            $email = $emailId . '+' . $serviceName . '@' . $domain;
+        }
 
         $user = User::whereEmail($email)->first();
 


### PR DESCRIPTION
There is breaking change in GoogleProvider between laravel/socialite:2.0.21 and laravel/socialite:2.0.22

https://github.com/laravel/socialite/releases/tag/v2.0.22
```
/**
     * {@inheritdoc}
     */
    protected function mapUserToObject(array $user)
    {
        $avatarUrl = Arr::get($user, 'picture');

        return (new User)->setRaw($user)->map([
            'id' => Arr::get($user, 'id'),
            'nickname' => Arr::get($user, 'nickname'),
            'name' => Arr::get($user, 'name'),
            'email' => Arr::get($user, 'email'),
            'avatar' => $avatarUrl,
            'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),
        ]);
    }

```

https://github.com/laravel/socialite/releases/tag/v2.0.21
```
 /**
     * {@inheritdoc}
     */
    protected function mapUserToObject(array $user)
    {
        return (new User)->setRaw($user)->map([
            'id' => $user['id'], 'nickname' => Arr::get($user, 'nickname'), 'name' => $user['displayName'],
            'email' => $user['emails'][0]['value'], 'avatar' => Arr::get($user, 'image')['url'],
            'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', Arr::get($user, 'image')['url']),
        ]);
    }
```
