### PR TITLE
Add an authentication service for the Microsoft OAuth2 On-Behalf-Of flow

### DIFF
--- a/src/Components/DfOAuthTwoProvider.php
+++ b/src/Components/DfOAuthTwoProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\RedirectResponse;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\OAuth2\User;
-use Log;
 
 /**
  * Trait DfOAuthTwoProvider
@@ -78,36 +77,10 @@ trait DfOAuthTwoProvider
         if ($this->hasInvalidState()) {
             throw new InvalidStateException();
         }
-        if(true){
-            $token_a_response = $this->getAccessTokenResponse($this->getCode());
-            Log::debug("[OAuth] Got response from Token A request: " . json_encode($token_a_response));
-            // exchange OAuth access_token "Token A" for OBO access_token "Token B"
-            $tokenA = $this->parseAccessToken($token_a_response);
-            Log::debug("[OAuth] Token A: " . $tokenA);
-            if(empty($tokenA)) {
-                throw new \InvalidArgumentException('Recieved invalid access_token from initial OAuth /token request.');
-            }else{
-                $graph_response = $this->getGraphTokenResponse($tokenA);
-                Log::debug("[OAuth] Got response from Graph Token B request: " . json_encode($graph_response));
-                $user = $this->createUserFromGraphTokenResponse($graph_response);
 
-                $obo_response = $this->getOBOTokenResponse($tokenA);
-                Log::debug("[OAuth] Got response from Snowflake Token B request: " . json_encode($obo_response));
-                return $this->setUserAccessTokenFromResponse($user, $obo_response);
-            }
-        }
-    }
-    
-    /**
-     * Retrieve user using token response.
-     *
-     * @param $response
-     *
-     * @return $this
-     */
-    public function createUserFromGraphTokenResponse($response)
-    {
-        return $this->mapUserToObject($this->getUserByToken($this->parseAccessToken($response)));
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        return $this->getUserFromTokenResponse($response);
     }
 
     /**
@@ -117,9 +90,11 @@ trait DfOAuthTwoProvider
      *
      * @return $this
      */
-    public function setUserAccessTokenFromResponse($user, $response)
+    public function getUserFromTokenResponse($response)
     {
-        $token = $this->parseAccessToken($response);
+        $user = $this->mapUserToObject($this->getUserByToken(
+            $token = $this->parseAccessToken($response)
+        ));
 
         $this->credentialsResponseBody = $response;
 

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DreamFactory\Core\Models\User;
 use DreamFactory\Core\OAuth\Components\DfOAuthOneProvider;
 use DreamFactory\Core\OAuth\Components\DfOAuthTwoProvider;
+use DreamFactory\Core\OAuth\Components\DfOAuthTwoOboProvider;
 use DreamFactory\Core\OAuth\Models\OAuthTokenMap;
 use DreamFactory\Core\Services\BaseRestService;
 use DreamFactory\Core\Utility\Session;
@@ -109,9 +110,10 @@ abstract class BaseOAuthService extends BaseRestService
         /** @var RedirectResponse $response */
         $response = $this->provider->redirect();
         $traitsUsed = class_uses($this->provider);
+        $traitTwoObo = DfOAuthTwoOboProvider::class;
         $traitTwo = DfOAuthTwoProvider::class;
         $traitOne = DfOAuthOneProvider::class;
-        if (isset($traitsUsed[$traitTwo])) {
+        if (isset($traitsUsed[$traitTwo]) || isset($traitsUsed[$traitTwoObo])) {
             $state = $this->provider->getState();
             if (!empty($state)) {
                 $key = static::CACHE_KEY_PREFIX . $state;


### PR DESCRIPTION
This PR adds a new `DfOAuthTwoOboProvider` trait, which implements the modified user authentication flow, needed to implement the Microsoft OAuth 2.0 On-Behalf-Of flow. The most important change is to the `public function user()` function, which requests an initial OAuth token, but now must request two additional access tokens through the OBO flow. One token will be used to access the target API resource, and one will be used to load the authenticated user's data from Microsoft Graph.

See also, the accompanying PR in the df-azure-ad repo.