### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,20 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-core":              "~1.0",
-    "laravel/socialite":                 "~2.0|~4.2|^5.0.0",
-    "socialiteproviders/microsoft-live": "^2.0|^3.0|^4.1.0",
-    "socialiteproviders/twitter":        "^2.0|^3.0|^4.1.0",
-    "ext-json": "*"
+    "php":                               "^8.3",
+    "ext-json":                          "*",
+    "laravel/helpers":                   "^1.8",
+    "dreamfactory/df-core":              "~1.0.4",
+    "laravel/socialite":                 "^5.20",
+    "socialiteproviders/microsoft-live": "^4.1",
+    "socialiteproviders/twitter":        "^4.1"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -354,8 +354,9 @@ abstract class BaseOAuthService extends BaseRestService
         }
 
         return true;
-     
-     /**
+    }
+
+    /**
      * Get the appropriate redirect base URL based on environment
      */
     private function getRedirectBaseUrl()


### PR DESCRIPTION
## Summary
- Wave 2 of the L11 -> L13 upgrade campaign for the DreamFactory monorepo.
- Bumps `df-oauth`'s dependency matrix to support Laravel 13.7 / PHP 8.3 / PHPUnit 11, aligning with the upgraded `df-core`, `df-system`, `df-database`, `df-sqldb`, and `df-user` packages already on `shift/laravel-13`.
- Fixes a pre-existing parse error in `BaseOAuthService::isValidRedirectUrl()` (missing closing brace) that broke autoloading on any PHP install.

## Composer changes
- Require `php ^8.3`
- Add `laravel/helpers ^1.8` (polyfills `array_get` / `camel_case` / `array_except` consumed by df-core)
- Pin `dreamfactory/df-core ~1.0.4` (the L13-line tag baseline)
- Bump `laravel/socialite` from `~2.0|~4.2|^5.0.0` -> `^5.20` (5.27 declares `illuminate/http` `^13.0` support)
- Tighten `socialiteproviders/microsoft-live` and `socialiteproviders/twitter` from `^2.0|^3.0|^4.1.0` -> `^4.1` (the `Manager` 4.x line, which supports socialite ^5.5+)
- Introduce a `require-dev` block: `laravel/framework ^13.7`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`

## Source change
- Restore the missing `}` closing `BaseOAuthService::isValidRedirectUrl()`. Without this fix the trailing `private function getRedirectBaseUrl()` declaration could never load, fataling at parse time.

## Verification
**Stage 1 (isolated package install with path-repo aliases for df-core/df-system/df-database):**
- `composer validate --strict`: clean
- `composer install` (no-dev): resolves cleanly, installs Laravel 13.7.0, Socialite 5.27.0, SocialiteProviders Manager 4.9.2, microsoft-live 4.1.0, twitter 4.1.2
- `composer install --dev`: resolves cleanly, PHPUnit 11.5.55 + Testbench 11.1.0
- `php -l` over `src/` and `tests/`: 0 errors after the brace fix
- Autoload smoke: 32/32 namespaced classes resolve, both OAuth1/OAuth2 traits resolve, helper polyfills present, `Laravel\Socialite\SocialiteServiceProvider` reachable
- Reflection check: `AzureADProvider extends Laravel\Socialite\Two\AbstractProvider`, `BitbucketProvider extends SocialiteProviders\Manager\OAuth1\AbstractProvider`, `TwitterProvider extends SocialiteProviders\Twitter\Provider`, `BaseOAuthService extends DreamFactory\Core\Services\BaseRestService` — all parents reachable on Socialite 5.27 + Manager 4.9

**Stage 2 (host app `shift-173254` worktree, with `df-mongo-logs`/`df-git`/`df-mcp-server` stripped, `MongoDB\\Laravel\\MongoDBServiceProvider` commented; `df-oauth` itself kept and path-repo'd):**
- `composer install --no-dev`: resolves cleanly, package:discover sees df-oauth, laravel/socialite, socialiteproviders/manager
- Autoload smoke: 32/32 df-oauth classes resolve under the integrated app
- `Illuminate\Foundation\Application::VERSION === '13.7.0'` confirmed

## Tests
The three existing `tests/*.php` files extend `PHPUnit\Framework\TestCase` directly (no host-app bootstrap). They exhibit the same pre-existing failure mode as df-system/df-sqldb tests under isolation - they reach for the `Log` facade root and df-core utilities that require the full app container. PHPUnit 11.5 itself runs cleanly; the test harness gaps predate this PR and are tracked by a separate effort.

## What is not changed
- No CorsService / DispatchesJobs / `getDates()` / `setupBeforeClass` / `ConnectionInterface::select` LSP work was needed - none of those L13 invariant patterns appear in df-oauth's source.
- No migration changes; the existing `Illuminate\Database\Migrations\Migration` extension API is unchanged in L13.
- `ServiceProvider::boot()` continues to use `loadMigrationsFrom()` and `commands()` - both unchanged in L13.

## Test plan
- [ ] CI green on `shift/laravel-13`
- [ ] Manual smoke: an integrated build of `dreamfactory/dreamfactory#shift-173254` boots with this branch as the OAuth provider source
- [ ] Spot-check Azure AD authorization-code login + client-credentials token flow against a tenant
- [ ] Spot-check at least one OAuth2 provider (Google/GitHub) and one OAuth1 provider (Twitter or Bitbucket) - their parent classes have moved between Socialite 4.x and 5.x lines