### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,20 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-core":              "~1.0",
-    "laravel/socialite":                 "~2.0|~4.2|^5.0.0",
-    "socialiteproviders/microsoft-live": "^2.0|^3.0|^4.1.0",
-    "socialiteproviders/twitter":        "^2.0|^3.0|^4.1.0",
-    "ext-json": "*"
+    "php":                               "^8.3",
+    "ext-json":                          "*",
+    "laravel/helpers":                   "^1.8",
+    "dreamfactory/df-core":              "~1.0.4",
+    "laravel/socialite":                 "^5.20",
+    "socialiteproviders/microsoft-live": "^4.1",
+    "socialiteproviders/twitter":        "^4.1"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Components/DfOAuthTwoProvider.php
+++ b/src/Components/DfOAuthTwoProvider.php
@@ -63,10 +63,15 @@ trait DfOAuthTwoProvider
         if ($this->isStateless()) {
             return false;
         }
-        $urlState = $this->request->input('state');
-        $cacheState = \Cache::pull($urlState);
+        $urlState = (string) $this->request->input('state');
+        $cacheState = (string) \Cache::pull($urlState);
 
-        return !(strlen($cacheState) > 0 && $urlState === $cacheState);
+        // Use hash_equals for constant-time comparison. The OAuth state
+        // token is a CSRF-prevention nonce; even though both sides are
+        // CSPRNG-generated, comparing with === leaks length + position
+        // information via timing, and consistency with other token
+        // comparisons in the codebase matters.
+        return !(strlen($cacheState) > 0 && hash_equals($cacheState, $urlState));
     }
 
     /**

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -354,8 +354,9 @@ abstract class BaseOAuthService extends BaseRestService
         }
 
         return true;
-     
-     /**
+    }
+
+    /**
      * Get the appropriate redirect base URL based on environment
      */
     private function getRedirectBaseUrl()

--- a/src/Services/BaseOAuthService.php
+++ b/src/Services/BaseOAuthService.php
@@ -325,12 +325,24 @@ abstract class BaseOAuthService extends BaseRestService
      */
     protected function isValidRedirectUrl($url)
     {
-        // Must be a valid URL
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        // filter_var(URL) accepts URLs with credentials in the userinfo
+        // section (e.g. http://127.0.0.1:1234@attacker.com) which makes
+        // the host appear to be 127.0.0.1 to a casual reader but the
+        // request actually goes to attacker.com. We do our own scheme +
+        // host check via parse_url and ignore filter_var for everything
+        // except basic structural sanity.
+        if (!is_string($url) || $url === '') {
             return false;
         }
-
         $parsed = parse_url($url);
+        if ($parsed === false || empty($parsed['scheme']) || empty($parsed['host'])) {
+            return false;
+        }
+        // Reject any URL that includes userinfo credentials — these are
+        // a known phishing technique to make malicious URLs look benign.
+        if (!empty($parsed['user']) || !empty($parsed['pass'])) {
+            return false;
+        }
 
         // Must be HTTPS in production (allow HTTP in debug mode for local development)
         if (!config('app.debug') && ($parsed['scheme'] ?? '') !== 'https') {
@@ -345,16 +357,48 @@ abstract class BaseOAuthService extends BaseRestService
             $whitelist = $appHost ? [$appHost] : [];
         }
 
-        $host = $parsed['host'] ?? '';
+        $host = strtolower($parsed['host'] ?? '');
         $allowed = false;
         foreach ($whitelist as $pattern) {
-            if (fnmatch($pattern, $host)) {
+            if (self::hostMatchesPattern($host, (string) $pattern)) {
                 $allowed = true;
                 break;
             }
         }
 
         return $allowed;
+    }
+
+    /**
+     * Strict host match. Replaces fnmatch, which is glob-based and
+     * accepts wildcards in unsafe positions (e.g., admin configures
+     * `example.com*` which matches `example.com.attacker.com`).
+     *
+     * Allowed pattern shapes:
+     *   - exact host (case-insensitive)         e.g. `example.com`
+     *   - leading-wildcard subdomain match      e.g. `*.example.com`
+     *
+     * Anything more permissive must be expressed as multiple entries.
+     */
+    public static function hostMatchesPattern(string $host, string $pattern): bool
+    {
+        $host = strtolower($host);
+        $pattern = strtolower($pattern);
+
+        if ($pattern === '') {
+            return false;
+        }
+        if ($host === $pattern) {
+            return true;
+        }
+        if (str_starts_with($pattern, '*.')) {
+            $suffix = substr($pattern, 1); // ".example.com"
+            // Must end with the suffix and have at least one extra label.
+            if (str_ends_with($host, $suffix) && strlen($host) > strlen($suffix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/Security/HostMatchTest.php
+++ b/tests/Security/HostMatchTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DreamFactory\Core\OAuth\Tests\Security;
+
+use DreamFactory\Core\OAuth\Services\BaseOAuthService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: hostMatchesPattern must be strict; replaces fnmatch which
+ * accepts unsafe wildcards.
+ */
+class HostMatchTest extends TestCase
+{
+    /** @dataProvider matchProvider */
+    public function testMatch(string $host, string $pattern, bool $expected): void
+    {
+        $this->assertSame($expected, BaseOAuthService::hostMatchesPattern($host, $pattern));
+    }
+
+    public static function matchProvider(): array
+    {
+        return [
+            // Exact host
+            ['example.com', 'example.com', true],
+            ['EXAMPLE.com', 'example.com', true],
+            ['evil.com', 'example.com', false],
+
+            // Leading-wildcard subdomain
+            ['app.example.com', '*.example.com', true],
+            ['admin.example.com', '*.example.com', true],
+            ['example.com', '*.example.com', false],          // bare host doesn't match *.host
+            ['evil.com', '*.example.com', false],
+            // The fnmatch bypass: pattern as a glob would let
+            // `evil.example.com.attacker.com` match `*.example.com`.
+            // Our strict matcher must reject it.
+            ['evil.example.com.attacker.com', '*.example.com', false],
+
+            // Leading-wildcard does not let a host suffix match different-domain
+            ['attacker-example.com', '*.example.com', false],
+
+            // Empty pattern is rejected
+            ['anything.com', '', false],
+        ];
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master (NOTE: master ahead of develop)

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

> ⚠️ `master` has commits not in `develop` — listed below. GitHub will
> create a merge commit; both histories are preserved. Reviewer:
> verify the divergent master commits aren't logically conflicting
> with the develop work before merging.

### Verification

The develop HEAD here is the SHA locked into the L13/PHP 8.5 test
bundle. **Full end-to-end smoke passed 2026-05-26** (PHP 8.5.5,
Laravel 13.11.2, df:setup, login, CRUD, OpenAPI gen).

### Coordinated release PRs

One of ~26 coordinated release PRs. Merge order:
foundation → connectors → auth → services → AI → admin UI → host app.
